### PR TITLE
Improve tag counting

### DIFF
--- a/lektor_tags.py
+++ b/lektor_tags.py
@@ -243,7 +243,8 @@ class TagsPlugin(Plugin):
         tagcount = collections.Counter()
         for page in get_ctx().pad.query(self.get_parent_path()):
             with contextlib.suppress(KeyError, TypeError):
-                tagcount.update(page[self.get_tag_field_name()])
+                page_tags = set(page[self.get_tag_field_name()])
+                tagcount.update(page_tags)
         return tagcount
 
     def tagweights(self):

--- a/lektor_tags.py
+++ b/lektor_tags.py
@@ -241,10 +241,12 @@ class TagsPlugin(Plugin):
         # Count tags, to be aggregated as "tag weights". Note that tags that
         # only appear in non-discoverable pages are ignored.
         tagcount = collections.Counter()
-        for page in get_ctx().pad.query(self.get_parent_path()):
+        pad = get_ctx().pad
+        all_tags = self.get_all_tags(pad.get(self.get_parent_path()))
+        for page in pad.query(self.get_parent_path()):
             with contextlib.suppress(KeyError, TypeError):
                 page_tags = set(page[self.get_tag_field_name()])
-                tagcount.update(page_tags)
+                tagcount.update(page_tags.intersection(all_tags))
         return tagcount
 
     def tagweights(self):

--- a/tests/demo-project/content/blog/post2/contents.lr
+++ b/tests/demo-project/content/blog/post2/contents.lr
@@ -2,5 +2,6 @@ tags:
 
 tag1
 tag3
+tag3
 ---
 published: False

--- a/tests/test_tagweights.py
+++ b/tests/test_tagweights.py
@@ -23,6 +23,13 @@ def test_tagcount(tags_plugin):
 
 
 @pytest.mark.usefixtures("lektor_context")
+def test_tagcount_limit_tags(tags_plugin):
+    config = tags_plugin.get_config()
+    config["tags"] = "['tag1', 'tag2']"
+    assert tags_plugin.tagcount() == Counter({"tag1": 2, "tag2": 1})
+
+
+@pytest.mark.usefixtures("lektor_context")
 def test_tagweights(tags_plugin):
     assert tags_plugin.tagweights() == {
         "tag1": TagWeight(2, 1, 2),


### PR DESCRIPTION
I found two (minor) issues with counting tags:

1. Duplicates could be used to skew the tag count. For example, a page with a duplicate tag would be counted twice for that tag.
2. The list of all tags can be configured for the plugin, but tag counting did not consider this configuration option.